### PR TITLE
Typo fixes, expand a few comments

### DIFF
--- a/notebooks/advanced_topics/IDC_Recipes_Conversion.ipynb
+++ b/notebooks/advanced_topics/IDC_Recipes_Conversion.ipynb
@@ -110,7 +110,7 @@
    "source": [
     "### Sample data for conversion examples\n",
     "\n",
-    "Expore and download IDC data here: https://portal.imaging.datacommons.cancer.gov/explore/\n",
+    "Explore and download IDC data here: https://portal.imaging.datacommons.cancer.gov/explore/\n",
     "\n",
     "Examples below used [TCGA-ACC](https://portal.imaging.datacommons.cancer.gov/explore/filters/?Modality_op=OR&Modality=SM&collection_id=tcga_acc)\n",
     "\n",
@@ -218,9 +218,13 @@
    ],
    "source": [
     "# Convert SVS to DICOM with precompressed tiles\n",
+    "# This will copy tiles from the original SVS, so tile sizes do not need to be specified\n",
+    "\n",
+    "# The '-compression' option currently must match the compression type of the input data.\n",
+    "# This will be fixed in a future version of Bio-Formats.\n",
     "\n",
     "# Convert using bfconvert\n",
-    "!./bftools/bfconvert -precompressed -compression JPEG -overwrite rgb-svs/CMU-1-Small-Region.svs rgb-svs/CMU-1-Small-Region.dcm\n"
+    "!./bftools/bfconvert -noflat -precompressed -compression JPEG -overwrite rgb-svs/CMU-1-Small-Region.svs rgb-svs/CMU-1-Small-Region.dcm\n"
    ]
   },
   {
@@ -278,6 +282,14 @@
     "\n",
     "# Convert using bfconvert with non-default options:\n",
     "# Crop the full resolution image and drop the resolution pyramid because the output image is small\n",
+    "# A 1000x1000 region of the full resolution image starting at (5000,5000) will be converted.\n",
+    "\n",
+    "# Tile sizes do not need to be specified if the tile dimensions in the original DICOM should be preserved,\n",
+    "# but here tiles are explicitly set to 512x512 to demonstrate the '-tilex' and '-tiley' options.\n",
+    "\n",
+    "# If converting the entire input dataset instead:\n",
+    "# - omit the '-crop 5000,5000,1000,1000' option\n",
+    "# - replace the '-series 0' option with '-noflat'\n",
     "\n",
     "!./bftools/bfconvert -series 0 -compression JPEG-2000 -crop 5000,5000,1000,1000 -overwrite -tilex 512 -tiley 512 rgb-dicom/5ee2770f-b222-4565-a3bd-46ba294ca222.dcm rgb-dicom/output.ome.tiff\n"
    ]
@@ -592,6 +604,7 @@
    ],
    "source": [
     "# Convert DICOM to OME-TIFF with bioformats2raw/raw2ometiff default options\n",
+    "# The resulting OME-TIFF will use LZW compression, so is likely to be much larger than the input data.\n",
     "\n",
     "# TIP: If conversion fails with \"java.lang.NoClassDefFoundError: Could not initialize class org.blosc.IBloscDll\"\n",
     "# Follow instructions here for Blosc installation: https://github.com/glencoesoftware/bioformats2raw/?tab=readme-ov-file#requirements\n",
@@ -625,10 +638,12 @@
    ],
    "source": [
     "# Convert DICOM to OME-TIFF with bioformats2raw/raw2ometiff with specification of compression, tile size, etc.\n",
+    "# The '--rgb' and '--compression \"JPEG-2000\"' options to raw2ometiff should produce a file that is much smaller than\n",
+    "# with default options.\n",
     "\n",
     "!./bioformats2raw-0.9.3/bin/bioformats2raw rgb-dicom/5ee2770f-b222-4565-a3bd-46ba294ca222.dcm rgb-dicom/output.zarr --tile_width 512 --tile_height 512 --overwrite\n",
     "#!./bioformats2raw-0.9.3/bin/bioformats2raw rgb-dicom/5ee2770f-b222-4565-a3bd-46ba294ca222.dcm rgb-dicom/output.zarr --tile_width 512 --tile_height 512 --overwrite --compression zlib\n",
-    "!./raw2ometiff-0.7.1/bin/raw2ometiffraw2ometiff rgb-dicom/output.zarr rgb-dicom/output-options.ome.tiff -rgb --compression \"JPEG-2000\"\n"
+    "!./raw2ometiff-0.7.1/bin/raw2ometiff rgb-dicom/output.zarr rgb-dicom/output-options.ome.tiff --rgb --compression \"JPEG-2000\"\n"
    ]
   },
   {
@@ -1988,8 +2003,14 @@
    ],
    "source": [
     "# Convert fluoresence data using bfconvert - cropping a subset due to its size\n",
+    "# A 1000x1000 region of the full resolution image starting at (0,0) is saved.\n",
+    "# The pyramid is omitted due to the small output image size.\n",
     "\n",
-    "!./bftools/bfconvert -crop 0,0,1000,1000 fluo/5f1c1b2e-60d4-4fae-a783-5b029ebd6db0.dcm fluo/fluo-cropped.ome.tiff\n"
+    "# If converting the entire input dataset instead:\n",
+    "# - omit the '-crop 0,0,1000,1000' option\n",
+    "# - replace the '-series 0' option with '-noflat'\n",
+    "\n",
+    "!./bftools/bfconvert -series 0 -crop 0,0,1000,1000 fluo/5f1c1b2e-60d4-4fae-a783-5b029ebd6db0.dcm fluo/fluo-cropped.ome.tiff\n"
    ]
   },
   {


### PR DESCRIPTION
Mostly as the PR title indicates, but note:

* Line 227 adds `-noflat`, which shouldn't matter for `CMU-1-Small-Region.svs` (which has no pyramid), but matters a lot for most real-world SVS input data (which will have a pyramid).
* Line 2013 adds `-series 0` to be consistent with the earlier cropping example.
* If running this locally, Windows won't be supported (things like `wget` aren't available). Worth asking on the upstream PR if that's needed though, since it's not a quick fix.
* Since it doesn't run on Windows and I don't have a suitable non-Windows environment, probably just needs a quick double-check that everything runs without error before opening the upstream PR.

